### PR TITLE
Re-enable picking of latest available version

### DIFF
--- a/cemutil.sh
+++ b/cemutil.sh
@@ -21,8 +21,8 @@ function printhelp {
 
 function downloadlatest {
 	echo "Downloading latest cemu"
-	#wget -q --show-progress -O cemutemp.zip $(curl -s http://cemu.info |grep .zip |awk -F '"' {'print $2'})
-	wget -q --show-progress -O cemutemp.zip http://cemu.info/releases/cemu_1.15.0.zip
+	wget -q --show-progress -O cemutemp.zip $(curl -s http://cemu.info |grep .zip |awk -F '"' {'print $2'})
+	#wget -q --show-progress -O cemutemp.zip http://cemu.info/releases/cemu_1.15.0.zip
 	echo "Downloading latest cemuhook"
 	wget -q --show-progress -O cemuhooktemp.zip $(curl -s https://cemuhook.sshnuke.net |grep .zip |awk -F '"' NR==2{'print $2'})
 	echo "Downloading latest graphics packs"

--- a/cemutil.sh
+++ b/cemutil.sh
@@ -194,3 +194,4 @@ echo "You may place LaunchCEMU anywhere, and even pass arguments to it just like
 echo "Note: When launching there may be a WxWidgets error. Press Cancel; this is normal from cemuhook"
 echo "Note2: gcn3 (radeon 300-500 series) users should use the gcn3BOTW script for launching BOTW"
 echo "Note3: Cemu Hook may not be able to download the 4 required shared fonts, these can be copied from a working Windows install of Cemu"
+echo "Note4: CEMU versions >= 1.15.4 utilize a built-in solution for in-game video playback. Turn on Debug -> 'Use CemuHook H264' if you are encountering any green screens."

--- a/cemutil.sh
+++ b/cemutil.sh
@@ -12,7 +12,7 @@ fi
 # help function:
 function printhelp {
 	echo "usage examples:"
-	echo "Download latest working cemu + cemuhook + graphic packs and install to ~/.cemu (default):"
+	echo "Download latest available cemu + cemuhook + graphic packs and install to ~/.cemu (default):"
 	echo "./cemutil.sh -a"
 	echo "Use local zips and install to ~/Documents/cemu:"
 	echo "./cemutil.sh -c cemu.zip -h cemuhook.zip -g graphicpacks.zip -i ~/Documents/cemu"


### PR DESCRIPTION
Have not encountered any issues when running > 1.15.0 versions with Wine >= 4.10.

Tested on:
1.15.1
1.15.2
1.15.3
1.15.4
1.15.5
1.15.9
1.15.10

However, the in 1.15.4 introduced video playback feature caused green screens in cut scenes so I added an additional warning to the post-install notes on how to switch back to cemuhook's solution.